### PR TITLE
Fix trakt_type for popular lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ app.get('/:configuration?/catalog/:type/:id/:extra?.json', (req, res) => {
 
 		}
 		else if (list_id == "popular") {
-			popular(type, genre, skip).then(metas => {
+			popular(trakt_type, genre, skip).then(metas => {
 				metas = metas.filter(function (element) {
 					return element !== undefined;
 				});

--- a/trakt-api.js
+++ b/trakt-api.js
@@ -34,13 +34,9 @@ async function request(url = String, header = Object) {
 
 }
 
-async function popular(type, genre, skip) {
+async function popular(trakt_type = String, genre, skip) {
 	try {
-		if (type == "movies") {
-			var url = `${host}/movies/popular?page=${skip}&limit=${count}&extended=full`;
-		} else if (type == "series") {
-			var url = `${host}/shows/popular?page=${skip}&limit=${count}&extended=full`;
-		}
+		var url = `${host}/${trakt_type}s/popular?page=${skip}&limit=${count}&extended=full`;
 
 		if (genre !== undefined) url += `&genres=${genre}`;
 
@@ -48,7 +44,7 @@ async function popular(type, genre, skip) {
 
 		if (!data || !data.data) throw "error getting data (recommended list)";
 
-		let items = ConvertToStremio(NormalizeLists(data.data));
+		let items = ConvertToStremio(NormalizeLists(data.data, trakt_type));
 		return items;
 	} catch (e) {
 		console.error(e);


### PR DESCRIPTION
Issue: Currently, the popular movies list is defaulting to type "series", making the list items fail when opening them.

Solution: Use "trakt_type" similar to trending lists